### PR TITLE
Fix port parsing in NSE enumeration script

### DIFF
--- a/nse_enumetation.sh
+++ b/nse_enumetation.sh
@@ -44,9 +44,9 @@ echo "[*] Parsing open ports from initial scan..."
 OPEN_PORTS=$(grep -i "Ports:" initial_scan.grep | \
   awk -F 'Ports: ' '{print $2}' | \
   awk -F 'Ignored ' '{print $1}' | \
-  sed 's/, /,/g' | tr ' ' '\n' | \
+  tr ',' '\n' | \
   grep open | \
-  cut -d '/' -f1 | \
+  cut -d '/' -f1 | tr -d ' ' | \
   tr '\n' ',' | sed 's/,$//')
 
 if [ -z "$OPEN_PORTS" ]; then


### PR DESCRIPTION
## Summary
- fix the parsing logic used to extract open ports in `nse_enumetation.sh`

## Testing
- `bash nse_enumetation.sh 192.168.1.1` *(fails: `nmap` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421ce21fbc833099e77f54915fe484